### PR TITLE
Disable logs in mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_NETWORK="[mainnet | testnet | local]"
+NEXT_PUBLIC_SHOW_LOGS_ON_MAINNET="[true | undefined]"

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -80,6 +80,7 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
         env:
           NEXT_PUBLIC_NETWORK: ${{ env.NEXT_PUBLIC_NETWORK }}
+          NEXT_PUBLIC_SHOW_LOGS_ON_MAINNET: ${{ env.NEXT_PUBLIC_SHOW_LOGS_ON_MAINNET }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,8 +13,20 @@ import { PageContainer } from '@/components/PageContainer';
 import OnchainContextProvider from '@/contexts/OnchainContextProvider';
 import WagmiContextProvider from '@/contexts/WagmiContextProvider';
 import { GlobalContextProvider } from '@/contexts/GlobalContext';
+import { getConfig } from '@/configs/config';
 
 const inter = Inter({ subsets: ['latin'] });
+
+const networkId = getConfig().networkData.networkId;
+
+console.log = function (...args) {
+  if (
+    process.env.NEXT_PUBLIC_SHOW_LOGS_ON_MAINNET === 'true' ||
+    networkId !== 'mainnet'
+  ) {
+    console.debug(...args);
+  }
+};
 
 const queryClient = new QueryClient();
 


### PR DESCRIPTION
Logs should only be shown while not in mainnet. Create a new variable in .env so they can be seen again in mainnet if it's wanted.